### PR TITLE
Update Cargo.toml to reduce Tokio features and clean up Cargo.lock; m…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,16 +625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,29 +679,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "paste"
@@ -873,15 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,12 +946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,10 +1004,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1167,7 +1120,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,18 @@ sha2 = "0.10.8"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
 
 # Async IO
-tokio = { version = "1.49.0", features = ["full"] }
-tokio-stream = "0.1.17"
-tokio-util = "0.7.15"
+tokio = { version = "1.49", features = [
+    "rt",
+    "net",
+    "io-util",
+    "sync",
+    "time",
+    "macros",
+    "rt-multi-thread",
+    "signals",
+] }
+tokio-stream = "0.1"
+tokio-util = "0.7"
 
 rmp = "0.8.14"
 rmp-serde = "1.3"

--- a/examples/ratchet.rs
+++ b/examples/ratchet.rs
@@ -51,10 +51,11 @@ async fn main() {
 
     let transport = Transport::new(TransportConfig::default());
 
-    let client_addr: AddressHash = transport.iface_manager().lock().await.spawn(
-        TcpClient::new("amsterdam.connect.reticulum.network:4965"),
-        TcpClient::spawn,
-    );
+    let client_addr: AddressHash = transport
+        .iface_manager()
+        .lock()
+        .await
+        .spawn(TcpClient::new("127.0.0.1:4242"), TcpClient::spawn);
     log::info!("TCP Client listening on {}", client_addr);
     let identity_path = "/tmp/client_identity";
     let _id = load_identity_from_file(identity_path).unwrap_or_else(|| {


### PR DESCRIPTION
### **User description**
…odify ratchet example to use localhost for TCP client


___

### **PR Type**
Enhancement


___

### **Description**
- Reduce Tokio dependency features from "full" to specific required features

- Update version constraints for tokio-stream and tokio-util to be more flexible

- Modify ratchet example to connect to localhost instead of remote server

- Fix trailing newline in Cargo.toml file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cargo.toml"] -->|"Reduce features"| B["Tokio config"]
  B -->|"Specify only needed"| C["rt, net, io-util, sync, time, macros, rt-multi-thread, signals"]
  D["examples/ratchet.rs"] -->|"Update endpoint"| E["127.0.0.1:4242"]
  E -->|"Replace"| F["amsterdam.connect.reticulum.network:4965"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cargo.toml</strong><dd><code>Reduce Tokio features and relax version constraints</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Cargo.toml

<ul><li>Replace Tokio "full" feature set with explicit minimal features: rt, <br>net, io-util, sync, time, macros, rt-multi-thread, and signals<br> <li> Relax version constraints for tokio-stream (0.1.17 → 0.1) and <br>tokio-util (0.7.15 → 0.7)<br> <li> Add trailing newline to file for proper formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/doubleailes/Reticulum-rs/pull/38/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+13/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ratchet.rs</strong><dd><code>Update ratchet example to use localhost endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/ratchet.rs

<ul><li>Change TCP client connection from <br>"amsterdam.connect.reticulum.network:4965" to "127.0.0.1:4242"<br> <li> Reformat method chain for better readability with each method on <br>separate line</ul>


</details>


  </td>
  <td><a href="https://github.com/doubleailes/Reticulum-rs/pull/38/files#diff-fa2ec036cd4a623be502b22d96f8693f2020111b3cde56877c847869fd9bcc71">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

